### PR TITLE
add Optim as dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MomentMatching"
 uuid = "a67aff5b-0ccc-47d5-9c4f-fef2ba9c9aa3"
 authors = ["Gualtiero Azzalini", "Zoltán Rácz"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
@@ -9,6 +9,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 JLD = "4138dd39-2aa7-5051-a626-17a0bb65d9c8"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"

--- a/src/MomentMatching.jl
+++ b/src/MomentMatching.jl
@@ -13,6 +13,7 @@ using Parameters: @with_kw, @unpack # For keywords in types
 using DocStringExtensions: FIELDS, TYPEDSIGNATURES, TYPEDEF # For easier documentation. Should we use it in the end?
 using CSV # For saving tables as output
 using DataFrames # For dealing with tables
+using Optim # For defining default settings for local optimization. Should think about how to avoid it.
 using Optimization # For local phase of estimation
 using Sobol # For global phase of estimation
 using ProgressMeter # For showing progress while running long computations


### PR DESCRIPTION
Until now relying on defaults in optimization setting threw an error (#70) , since NelderMead() was not defined within the package. Optimization cannot run without a set algorithm however, so it seems necessary to add Optim as a dependency now. There might be a more elegant solution, might try to figure out later.