### PR TITLE
export function to save light-weight version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MomentMatching"
 uuid = "a67aff5b-0ccc-47d5-9c4f-fef2ba9c9aa3"
 authors = ["Gualtiero Azzalini", "Zoltán Rácz"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/MomentMatching.jl
+++ b/src/MomentMatching.jl
@@ -44,13 +44,13 @@ export estimation, # main functions
        BootstrapResult,
        EmptyPredrawnShocks,
        estimation_name,
-       estimation_output_path,
        estimation_result_path,
        EstimationResult,
        EstimationSetup,
        @maythread,
        NumParMM,
        ParMM,
+       save_estimation_lightweight,
        threading_inside,
 
        # from inference.jl:

--- a/src/estimation.jl
+++ b/src/estimation.jl
@@ -649,6 +649,5 @@ macro maythread(body)
 end
 
 estimation_result_path() = "./saved/estimation_results/"
-estimation_output_path() = "./saved/estimation_output/"
 
 threading_inside() = false


### PR DESCRIPTION
also deleted path to output, which is unused